### PR TITLE
Fix critical bugs and improvements from code review

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -8,7 +8,7 @@ use Qdenka\Punycode\ValueObjects\Uri;
 
 class Converter implements ConverterContract
 {
-    static PunycodeConverter $converter;
+    private static ?PunycodeConverter $converter = null;
 
     /**
      * Encode the URL to Punycode.
@@ -34,7 +34,7 @@ class Converter implements ConverterContract
     public static function decode(string $url): string
     {
         $url = new Uri($url);
-        
+
         return self::getConverter()->decode($url);
     }
 
@@ -73,7 +73,7 @@ class Converter implements ConverterContract
      */
     private static function getConverter(): PunycodeConverter
     {
-        if (!isset(self::$converter)) {
+        if (self::$converter === null) {
             self::$converter = new PunycodeConverter();
         }
 

--- a/src/Identifier.php
+++ b/src/Identifier.php
@@ -7,24 +7,24 @@ use Qdenka\Punycode\Contracts\IdentifierContract;
 class Identifier implements IdentifierContract
 {
     /**
-     * Check if a string is in Punycode format.
+     * Check if a string (URL or domain) contains Punycode-encoded segments.
      *
      * @param string $string
      * @return bool
      */
     public static function isPunycode(string $string): bool
     {
-        return (strpos($string, 'xn--') === 0);
+        return strpos($string, 'xn--') !== false;
     }
 
     /**
-     * Check if a string contains Unicode characters.
+     * Check if a string contains non-ASCII (Unicode) characters.
      *
      * @param string $string
      * @return bool
      */
     public static function isUnicode(string $string): bool
     {
-        return mb_check_encoding($string, 'UTF-8');
+        return preg_match('/[^\x00-\x7F]/', $string) === 1;
     }
 }

--- a/src/Services/PunycodeConverter.php
+++ b/src/Services/PunycodeConverter.php
@@ -2,23 +2,23 @@
 
 namespace Qdenka\Punycode\Services;
 
-use Exception;
 use Qdenka\Punycode\Contracts\PunycodeDecoderContract;
 use Qdenka\Punycode\Contracts\PunycodeEncoderContract;
 use Qdenka\Punycode\Exceptions\ModuleNotFoundException;
 use Qdenka\Punycode\ValueObjects\Uri;
+use RuntimeException;
 
 /**
- * Class UrlPunycodeConverter
+ * Class PunycodeConverter
  *
  * This class is responsible for encoding and decoding URLs to and from Punycode.
  */
 final class PunycodeConverter implements PunycodeEncoderContract, PunycodeDecoderContract
 {
     /**
-     * UrlPunycodeConverter constructor.
+     * PunycodeConverter constructor.
      *
-     * @throws Exception
+     * @throws ModuleNotFoundException
      */
     public function __construct()
     {
@@ -56,10 +56,19 @@ final class PunycodeConverter implements PunycodeEncoderContract, PunycodeDecode
     /**
      * @param Uri $parsedUrl
      * @return Uri
+     * @throws RuntimeException
      */
     private function encodeParsedUri(Uri $parsedUrl): Uri
     {
-        $parsedUrl->setHost(idn_to_ascii($parsedUrl->getHost()));
+        $host = $parsedUrl->getHost();
+        if ($host !== '') {
+            $encoded = idn_to_ascii($host);
+            if ($encoded === false) {
+                throw new RuntimeException("Failed to encode host to Punycode: '{$host}'");
+            }
+            $parsedUrl->setHost($encoded);
+        }
+
         $parsedUrl->setPath($this->urlencode($parsedUrl->getPath()));
         $parsedUrl->setQuery($this->urlencode($parsedUrl->getQuery()));
         $parsedUrl->setFragment($this->urlencode($parsedUrl->getFragment()));
@@ -70,10 +79,19 @@ final class PunycodeConverter implements PunycodeEncoderContract, PunycodeDecode
     /**
      * @param Uri $parsedUrl
      * @return Uri
+     * @throws RuntimeException
      */
     private function decodeParsedUri(Uri $parsedUrl): Uri
     {
-        $parsedUrl->setHost(idn_to_utf8($parsedUrl->getHost()));
+        $host = $parsedUrl->getHost();
+        if ($host !== '') {
+            $decoded = idn_to_utf8($host);
+            if ($decoded === false) {
+                throw new RuntimeException("Failed to decode Punycode host: '{$host}'");
+            }
+            $parsedUrl->setHost($decoded);
+        }
+
         $parsedUrl->setPath(urldecode($parsedUrl->getPath()));
         $parsedUrl->setQuery(urldecode($parsedUrl->getQuery()));
         $parsedUrl->setFragment(urldecode($parsedUrl->getFragment()));
@@ -87,7 +105,7 @@ final class PunycodeConverter implements PunycodeEncoderContract, PunycodeDecode
      */
     private function urlencode(?string $uri): string
     {
-        if ($uri === null) {
+        if ($uri === null || $uri === '') {
             return '';
         }
 

--- a/src/ValueObjects/Uri.php
+++ b/src/ValueObjects/Uri.php
@@ -13,14 +13,21 @@ final class Uri
      */
     public function __construct(string $url)
     {
-        $this->uri = parse_url($url);
-        if ($this->uri === false) {
-            throw new InvalidUrlException('Invalid URL');
+        $parsed = parse_url($url);
+        if ($parsed === false) {
+            throw new InvalidUrlException('Invalid URL: unable to parse.');
         }
 
+        $this->uri = $parsed;
+
         if (!isset($this->uri['host'])) {
-            $this->uri['host'] = explode('/', $this->uri['path'])[0];
-            $this->uri['path'] = str_replace($this->uri['host'], '', $this->uri['path']);
+            $pathParts = explode('/', $this->uri['path'] ?? '');
+            $this->uri['host'] = $pathParts[0];
+            $this->uri['path'] = substr($this->uri['path'] ?? '', strlen($this->uri['host']));
+        }
+
+        if (!UriValidator::validate($this->uri)) {
+            throw new InvalidUrlException('Invalid URL: host is missing.');
         }
     }
 
@@ -59,7 +66,7 @@ final class Uri
     /**
      * @return string
      */
-    public function getFragment(): ?string
+    public function getFragment(): string
     {
         return $this->uri['fragment'] ?? '';
     }
@@ -67,7 +74,7 @@ final class Uri
     /**
      * @return string
      */
-    public function getUser(): ?string
+    public function getUser(): string
     {
         return $this->uri['user'] ?? '';
     }
@@ -75,7 +82,7 @@ final class Uri
     /**
      * @return string
      */
-    public function getPass(): ?string
+    public function getPass(): string
     {
         return $this->uri['pass'] ?? '';
     }
@@ -85,7 +92,7 @@ final class Uri
      */
     public function getPort(): string
     {
-        return $this->uri['port'] ?? '';
+        return isset($this->uri['port']) ? (string) $this->uri['port'] : '';
     }
 
     /**
@@ -93,12 +100,18 @@ final class Uri
      */
     public function getAuthority(): string
     {
-        $user = $this->getUser();
-        $pass = $this->getPass();
-        $pass = ($user || $pass) ? "$pass@" : '';
-        $port = $this->getPort();
+        $userInfo = '';
+        if ($this->getUser()) {
+            $userInfo = $this->getUser();
+            if ($this->getPass()) {
+                $userInfo .= ':' . $this->getPass();
+            }
+            $userInfo .= '@';
+        }
 
-        return $user . $pass . $this->getHost() . $port;
+        $port = $this->getPort() ? ':' . $this->getPort() : '';
+
+        return $userInfo . $this->getHost() . $port;
     }
 
     /**
@@ -111,6 +124,7 @@ final class Uri
         $path = $this->getPath();
         $query = $this->getQuery() ? '?' . $this->getQuery() : '';
         $fragment = $this->getFragment() ? '#' . $this->getFragment() : '';
+
         return "$scheme$host$path$query$fragment";
     }
 

--- a/src/ValueObjects/UriValidator.php
+++ b/src/ValueObjects/UriValidator.php
@@ -7,11 +7,13 @@ use Qdenka\Punycode\Contracts\ValidatorContract;
 class UriValidator implements ValidatorContract
 {
     /**
+     * Validate that the parsed URI contains a host.
+     *
      * @param array $uri
      * @return bool
      */
     public static function validate(array $uri): bool
     {
-        return isset($uri['host']);
+        return isset($uri['host']) && $uri['host'] !== '';
     }
 }

--- a/tests/ConverterTest.php
+++ b/tests/ConverterTest.php
@@ -2,14 +2,10 @@
 
 use PHPUnit\Framework\TestCase;
 use Qdenka\Punycode\Converter;
+use Qdenka\Punycode\Exceptions\InvalidUrlException;
 
 class ConverterTest extends TestCase
 {
-    public function __construct(string $name)
-    {
-        parent::__construct($name);
-    }
-
     public function testEncode(): void
     {
         $encodedUrl = Converter::encode('https://點看.com');
@@ -33,7 +29,13 @@ class ConverterTest extends TestCase
     {
         $urls = ['https://點看.com', 'https://домен.рф/testcase', 'сдай-лом.рф/пример', 'test.com/test', 'http://test2.com/test?uri=true'];
         $encodedUrls = Converter::encodeFromArray($urls);
-        $this->assertEquals(['https://xn--c1yn36f.com', 'https://xn--d1acufc.xn--p1ai/testcase', 'xn----7sblvlgns.xn--p1ai/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80', 'test.com/test', 'http://test2.com/test?uri=true'], $encodedUrls);
+        $this->assertEquals([
+            'https://xn--c1yn36f.com',
+            'https://xn--d1acufc.xn--p1ai/testcase',
+            'xn----7sblvlgns.xn--p1ai/%D0%BF%D1%80%D0%B8%D0%BC%D0%B5%D1%80',
+            'test.com/test',
+            'http://test2.com/test?uri=true',
+        ], $encodedUrls);
     }
 
     public function testFullUrlEncode(): void
@@ -41,6 +43,76 @@ class ConverterTest extends TestCase
         $url = 'https://привет.рф/мир/тест/#привет=мир';
         $encodedUrl = Converter::encode($url);
 
-        $this->assertEquals('https://xn--b1agh1afp.xn--p1ai/%D0%BC%D0%B8%D1%80/%D1%82%D0%B5%D1%81%D1%82/#%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=%D0%BC%D0%B8%D1%80', $encodedUrl);
+        $this->assertEquals(
+            'https://xn--b1agh1afp.xn--p1ai/%D0%BC%D0%B8%D1%80/%D1%82%D0%B5%D1%81%D1%82/#%D0%BF%D1%80%D0%B8%D0%B2%D0%B5%D1%82=%D0%BC%D0%B8%D1%80',
+            $encodedUrl
+        );
+    }
+
+    public function testEncodeUrlWithPort(): void
+    {
+        $encodedUrl = Converter::encode('https://домен.рф:8080/path');
+        $this->assertEquals('https://xn--d1acufc.xn--p1ai:8080/path', $encodedUrl);
+    }
+
+    public function testDecodeUrlWithPort(): void
+    {
+        $decodedUrl = Converter::decode('https://xn--d1acufc.xn--p1ai:8080/path');
+        $this->assertEquals('https://домен.рф:8080/path', $decodedUrl);
+    }
+
+    public function testEncodeUrlWithUserPass(): void
+    {
+        $encodedUrl = Converter::encode('https://user:pass@домен.рф/path');
+        $this->assertEquals('https://user:pass@xn--d1acufc.xn--p1ai/path', $encodedUrl);
+    }
+
+    public function testDecodeUrlWithUserPass(): void
+    {
+        $decodedUrl = Converter::decode('https://user:pass@xn--d1acufc.xn--p1ai/path');
+        $this->assertEquals('https://user:pass@домен.рф/path', $decodedUrl);
+    }
+
+    public function testEncodeUrlWithUserPassAndPort(): void
+    {
+        $encodedUrl = Converter::encode('https://user:pass@домен.рф:3000/path');
+        $this->assertEquals('https://user:pass@xn--d1acufc.xn--p1ai:3000/path', $encodedUrl);
+    }
+
+    public function testEncodeAsciiUrlUnchanged(): void
+    {
+        $url = 'https://example.com/path?query=1#frag';
+        $this->assertEquals($url, Converter::encode($url));
+    }
+
+    public function testDecodeAsciiUrlUnchanged(): void
+    {
+        $url = 'https://example.com/path?query=1#frag';
+        $this->assertEquals($url, Converter::decode($url));
+    }
+
+    public function testEncodeUrlWithQueryAndFragment(): void
+    {
+        $url = 'https://домен.рф/путь?запрос=да#фрагмент';
+        $encoded = Converter::encode($url);
+        $this->assertStringContainsString('xn--d1acufc.xn--p1ai', $encoded);
+        $this->assertStringContainsString('?', $encoded);
+        $this->assertStringContainsString('#', $encoded);
+    }
+
+    public function testInvalidUrlThrowsException(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        Converter::encode('');
+    }
+
+    public function testEmptyArrayEncode(): void
+    {
+        $this->assertEquals([], Converter::encodeFromArray([]));
+    }
+
+    public function testEmptyArrayDecode(): void
+    {
+        $this->assertEquals([], Converter::decodeFromArray([]));
     }
 }

--- a/tests/IdentifierTest.php
+++ b/tests/IdentifierTest.php
@@ -5,14 +5,53 @@ use Qdenka\Punycode\Identifier;
 
 class IdentifierTest extends TestCase
 {
-    public function testIsPunycode()
+    public function testIsPunycodeWithDomain(): void
     {
         $this->assertTrue(Identifier::isPunycode('xn--80ak6aa92e.com'));
+    }
+
+    public function testIsPunycodeWithFullUrl(): void
+    {
+        $this->assertTrue(Identifier::isPunycode('http://xn--tda.com/'));
+    }
+
+    public function testIsPunycodeWithSubdomain(): void
+    {
+        $this->assertTrue(Identifier::isPunycode('http://www.xn--tda.com/path'));
+    }
+
+    public function testIsNotPunycode(): void
+    {
         $this->assertFalse(Identifier::isPunycode('example.com'));
     }
 
-    public function testIsUnicode()
+    public function testIsNotPunycodeWithFullUrl(): void
+    {
+        $this->assertFalse(Identifier::isPunycode('https://example.com/path'));
+    }
+
+    public function testIsUnicodeWithCyrillic(): void
     {
         $this->assertTrue(Identifier::isUnicode('домен.рф'));
+    }
+
+    public function testIsUnicodeWithChinese(): void
+    {
+        $this->assertTrue(Identifier::isUnicode('點看.com'));
+    }
+
+    public function testIsUnicodeWithUmlauts(): void
+    {
+        $this->assertTrue(Identifier::isUnicode('münchen.de'));
+    }
+
+    public function testIsNotUnicodeWithAscii(): void
+    {
+        $this->assertFalse(Identifier::isUnicode('example.com'));
+    }
+
+    public function testIsNotUnicodeWithPunycode(): void
+    {
+        $this->assertFalse(Identifier::isUnicode('xn--80ak6aa92e.com'));
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Qdenka\Punycode\Exceptions\InvalidUrlException;
+use Qdenka\Punycode\ValueObjects\Uri;
+
+class UriTest extends TestCase
+{
+    public function testBasicUrlParsing(): void
+    {
+        $uri = new Uri('https://example.com/path');
+        $this->assertEquals('https', $uri->getScheme());
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('/path', $uri->getPath());
+    }
+
+    public function testUrlWithPort(): void
+    {
+        $uri = new Uri('https://example.com:8080/path');
+        $this->assertEquals('8080', $uri->getPort());
+        $this->assertEquals('https://example.com:8080/path', $uri->getUri());
+    }
+
+    public function testUrlWithUserPass(): void
+    {
+        $uri = new Uri('https://user:pass@example.com/path');
+        $this->assertEquals('user', $uri->getUser());
+        $this->assertEquals('pass', $uri->getPass());
+        $this->assertEquals('https://user:pass@example.com/path', $uri->getUri());
+    }
+
+    public function testUrlWithUserOnly(): void
+    {
+        $uri = new Uri('https://user@example.com/path');
+        $this->assertEquals('user', $uri->getUser());
+        $this->assertEquals('', $uri->getPass());
+        $this->assertEquals('https://user@example.com/path', $uri->getUri());
+    }
+
+    public function testUrlWithUserPassAndPort(): void
+    {
+        $uri = new Uri('https://user:pass@example.com:3000/path');
+        $this->assertEquals('https://user:pass@example.com:3000/path', $uri->getUri());
+    }
+
+    public function testUrlWithQueryAndFragment(): void
+    {
+        $uri = new Uri('https://example.com/path?key=value#section');
+        $this->assertEquals('key=value', $uri->getQuery());
+        $this->assertEquals('section', $uri->getFragment());
+        $this->assertEquals('https://example.com/path?key=value#section', $uri->getUri());
+    }
+
+    public function testDomainWithoutScheme(): void
+    {
+        $uri = new Uri('example.com/path');
+        $this->assertEquals('example.com', $uri->getHost());
+        $this->assertEquals('/path', $uri->getPath());
+    }
+
+    public function testToString(): void
+    {
+        $uri = new Uri('https://example.com/path');
+        $this->assertEquals('https://example.com/path', (string) $uri);
+    }
+
+    public function testSetters(): void
+    {
+        $uri = new Uri('https://example.com/path');
+        $uri->setHost('new.com');
+        $uri->setPath('/new-path');
+        $uri->setQuery('q=1');
+        $uri->setFragment('top');
+        $this->assertEquals('https://new.com/new-path?q=1#top', $uri->getUri());
+    }
+
+    public function testInvalidUrlThrowsException(): void
+    {
+        $this->expectException(InvalidUrlException::class);
+        new Uri('');
+    }
+}


### PR DESCRIPTION
## Summary

Комплексное исправление багов и доработка, выявленные при код-ревью.

## Critical Bugs Fixed

### 1. `Uri::getAuthority()` — порт без двоеточия
Порт приклеивался к хосту без `:`, превращая `example.com:8080` в `example.com8080`.

### 2. `Uri::getAuthority()` — user:pass без разделителя
Отсутствовал разделитель `:` между user и pass. Результат был `userpassword@host` вместо `user:password@host`. Также добавлена поддержка URL с user без password.

### 3. `Identifier::isPunycode()` — не работал с полными URL
Проверял `strpos($string, 'xn--') === 0` — возвращал `false` для `http://xn--tda.com/`. Исправлено на `!== false`.

### 4. `idn_to_ascii` / `idn_to_utf8` — нет обработки ошибок
Обе функции могут вернуть `false`, но это не проверялось. Добавлен `RuntimeException` при ошибке конвертации.

## Logic Improvements

### 5. `Identifier::isUnicode()` — ложные срабатывания
`mb_check_encoding()` возвращал `true` для любого валидного UTF-8, включая ASCII. Заменён на `preg_match('/[^\x00-\x7F]/')` для детекции реальных не-ASCII символов.

### 6. `UriValidator` — интеграция
Был создан, но нигде не использовался. Теперь вызывается в `Uri::__construct()` — бросает `InvalidUrlException` при отсутствии host.

### 7. `Uri` — фоллбэк хоста
`str_replace` заменял все вхождения хоста в path. Исправлено на `substr()` для точного отсечения.

### 8. `Converter::$converter` — nullable
Свойство объявлено как `?PunycodeConverter = null` вместо неинициализированного `PunycodeConverter`.

## Tests Added

- URL с портом (encode/decode)
- URL с user:pass (encode/decode)
- URL с user:pass + port
- Невалидные URL (`InvalidUrlException`)
- ASCII URL без изменений
- Пустые массивы
- `Identifier::isPunycode()` с полными URL
- `Identifier::isUnicode()` — корректная проверка ASCII vs Unicode
- Новый `UriTest.php` — полное покрытие `Uri` Value Object

## Return types
- `getFragment()`, `getUser()`, `getPass()` теперь возвращают `string` вместо `?string` для консистентности.